### PR TITLE
Update README with GitHub Pages image usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # badge-assets
+
 Storage for things like badge images for which we need a public url to use in the badge.
+
+Once you've added your image to the repo, you more than likely want to use the Github Pages link to the image, rather than the github raw url.
+
+So, for the DCC_Delft_Summit_Attendee.png image, for example, you'd point at the image with this url:
+
+```https://digitalcredentials.github.io/badge-assets/DCC_Delft_Summit_Attendee.png```
+
+The Github Pages link to the image sets the content-type as image, whereas the raw github url doesn't, and some consumers of the image might need the correct content type.


### PR DESCRIPTION
Suggest using the GitHub Pages url for badge images.